### PR TITLE
Add support for a manual text entry

### DIFF
--- a/Example/GooglePlacesSearchController/ViewController.swift
+++ b/Example/GooglePlacesSearchController/ViewController.swift
@@ -40,4 +40,9 @@ extension ViewController: GooglePlacesAutocompleteViewControllerDelegate {
         print(place.description)
         placesSearchController.isActive = false
     }
+    
+    func viewController(didManualCompleteWith text: String) {
+        print(text)
+        placesSearchController.isActive = false
+    }
 }

--- a/Pod/Classes/GooglePlacesSearchController.swift
+++ b/Pod/Classes/GooglePlacesSearchController.swift
@@ -139,11 +139,17 @@ open class GooglePlacesSearchController: UISearchController, UISearchBarDelegate
         self.hidesNavigationBarDuringPresentation = false
         self.definesPresentationContext = true
         self.searchBar.placeholder = searchBarPlaceholder
+        self.searchBar.returnKeyType = .done
+        if #available(iOS 13.0, *) {
+            self.searchBar.searchTextField.delegate = gpaViewController
+        }
     }
 }
 
 public protocol GooglePlacesAutocompleteViewControllerDelegate: class {
     func viewController(didAutocompleteWith place: PlaceDetails)
+    @available(iOS 13.0, *)
+    func viewController(didManualCompleteWith text: String)
 }
 
 open class GooglePlacesAutocompleteContainer: UITableViewController {
@@ -242,6 +248,17 @@ extension GooglePlacesAutocompleteContainer: UISearchBarDelegate, UISearchResult
         }
         
         return params
+    }
+}
+
+extension GooglePlacesAutocompleteContainer: UITextFieldDelegate {
+    
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let text = textField.text else { return false }
+        if #available(iOS 13.0, *) {
+            self.delegate?.viewController(didManualCompleteWith: text)
+        }
+        return true
     }
 }
 

--- a/Pod/Classes/GooglePlacesSearchController.swift
+++ b/Pod/Classes/GooglePlacesSearchController.swift
@@ -152,6 +152,11 @@ public protocol GooglePlacesAutocompleteViewControllerDelegate: class {
     func viewController(didManualCompleteWith text: String)
 }
 
+public extension GooglePlacesAutocompleteViewControllerDelegate {
+    @available(iOS 13.0, *)
+    func viewController(didManualCompleteWith text: String) {}
+}
+
 open class GooglePlacesAutocompleteContainer: UITableViewController {
     private weak var delegate: GooglePlacesAutocompleteViewControllerDelegate?
     
@@ -165,7 +170,6 @@ open class GooglePlacesAutocompleteContainer: UITableViewController {
     private var places = [Place]() {
         didSet { tableView.reloadData() }
     }
-    
     
     convenience init(delegate: GooglePlacesAutocompleteViewControllerDelegate, apiKey: String, placeType: PlaceType = .all, coordinate: CLLocationCoordinate2D, radius: Double, strictBounds: Bool) {
         self.init()


### PR DESCRIPTION
As described in issue #33, a user can only select a result from the list. This PR allows the user to press the keyboard return key to accept whatever text they have typed into the search bar, eg "Foo's house".

Note, this is only for iOS 13 and above.